### PR TITLE
feat: update plugin interface to be more babel-like

### DIFF
--- a/example-kappa-plugins/ApplyQNotationPlugin.js
+++ b/example-kappa-plugins/ApplyQNotationPlugin.js
@@ -1,13 +1,10 @@
 export default class ApplyQNotationPlugin {
-  nodeTypes = ['BinaryOperator'];
-
-  async visit(node, visitor) {
+  async visitBinaryOperator(node, visitor) {
     if (node.detail === '=' && node.children?.[1].kind === 'IntegerLiteral') {
       const leftChild = node.children[0];
 
       if (leftChild.children?.[0] && visitor.getNodeType(leftChild.children[0]) === 'Vec2_32') {
         const leftChildType = visitor.getNodeType(leftChild);
-        console.log(`Assignment to variable of type: ${leftChildType}`);
 
         if (leftChildType === 's32') {
           const rightChild = node.children[1];

--- a/example-kappa-plugins/DoubleIntAssignmentPlugin.js
+++ b/example-kappa-plugins/DoubleIntAssignmentPlugin.js
@@ -1,12 +1,9 @@
 export default class DoubleIntAssignmentPlugin {
-  nodeTypes = ['BinaryOperator'];
-
-  async visit(node, visitor) {
+  async visitBinaryOperator(node, visitor) {
     if (node.detail === '=' && node.children?.[1].kind === 'IntegerLiteral') {
       const leftChild = node.children[0];
 
       const leftChildType = visitor.getNodeType(leftChild);
-      console.log(`Assignment to variable of type: ${leftChildType}`);
 
       if (leftChildType === 'int') {
         const rightChild = node.children[1];

--- a/example-kappa-plugins/DummyPlugin.js
+++ b/example-kappa-plugins/DummyPlugin.js
@@ -1,7 +1,5 @@
 export default class TestPlugin {
-  nodeTypes = ['*']; // Handle all node types
-
-  async visit(node, visitor) {
+  async visitAny(node, visitor) {
     console.log(`TestPlugin visited node of type: ${node.kind}`);
   }
 }

--- a/src/load-kappa-plugins.ts
+++ b/src/load-kappa-plugins.ts
@@ -54,14 +54,15 @@ export async function loadKappaPlugins(visitor: ASTVisitor): Promise<void> {
         // Create an instance of the plugin
         const pluginInstance: ASTVisitorPlugin = new PluginClass();
 
-        // Validate that it implements the ASTVisitorPlugin interface
-        if (!pluginInstance.nodeTypes || !Array.isArray(pluginInstance.nodeTypes)) {
-          vscode.window.showWarningMessage(`Skipping plugin \`${jsFile}\`: Invalid nodeTypes array`);
-          continue;
-        }
+        // Validate that plugin has at least one visit method
+        const foundVisitMethod = Boolean(
+          Object.getOwnPropertyNames(Object.getPrototypeOf(pluginInstance))
+            .concat(Object.getOwnPropertyNames(pluginInstance))
+            .find((name) => name.startsWith('visit')),
+        );
 
-        if (typeof pluginInstance.visit !== 'function') {
-          vscode.window.showWarningMessage(`Skipping plugin \`${jsFile}\`: Invalid visit method`);
+        if (!foundVisitMethod) {
+          vscode.window.showWarningMessage(`Skipping plugin \`${jsFile}\`: No valid node handler methods found`);
           continue;
         }
 


### PR DESCRIPTION
Update `ASTVisitorPlugin` interface to be closer to a [babel plugin](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md).

Instead of defining a list of nodes to visit and a global `visit` method, now it should have a method per node kind.